### PR TITLE
[Update] Contact page

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -291,6 +291,12 @@ main article img, main article video{
   background: white;
   margin-bottom: 1em;
   max-width: 100%;
+
+  &.blend {
+    background: none;
+    border: none;
+    box-shadow: none;
+  }
 }
 
 .youtube-iframe {

--- a/views/contact-us.md
+++ b/views/contact-us.md
@@ -3,7 +3,14 @@ layout: page
 title: Contact Us
 permalink: /contact-us/
 ---
-If you're a developer or publisher grappling with similar challenges to us, we'd love to hear from you.  You can find us on [Twitter](https://twitter.com/ftlabs), or [Github](https://github.com/ftlabs), or drop us a line to [{{site.email}}](mailto:{{site.email}}).
+{% include figure.html src="/assets/imgs/blue-labs-logo_new.png"
+alt="FT Labs"
+width="150"
+class="blend"
+%}
+This is the contact page for the FT Labs team. If you're a developer or publisher grappling with similar challenges to us, we'd love to hear from you.  You can find us on [Twitter](https://twitter.com/ftlabs), or [Github](https://github.com/ftlabs), or drop us a line to [{{site.email}}](mailto:{{site.email}}).
+
+For other Financial Times enquiries, please visit the [FT's support page](https://aboutus.ft.com/en-gb/contact-us/).
 
 ## Visiting us
 


### PR DESCRIPTION
## Description
SEO gives Labs' contact page before the FT's resulting in random queries coming to us.
An update to our contact page may improve getting queries to the right people.

## Implementation
- add Labs logo 
- Rephrase first paragraph.
- link to FT contact page
- add a `blend` class for images to remove white background/borders on pngs when necessary

## Screenshot
![Screenshot 2019-03-13 at 10 12 20](https://user-images.githubusercontent.com/3882381/54271058-a6e61780-4578-11e9-9257-eaa29d56f8e8.png)

