### PR TITLE
Amend/twitter metadata

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,6 +38,7 @@ exclude:
 default-image-width: 300
 excerpt_separator: ""
 logo-background-image: /assets/imgs/Blue-red-yellow.png
+preview-image: /assets/imgs/blue-labs-logo_new.png
 collections:
   author:
     output: true

--- a/_includes/head-facebook.html
+++ b/_includes/head-facebook.html
@@ -1,0 +1,4 @@
+<meta property="og:type"        content="article" />
+<meta property="og:title"       content="{{ page.title | default: site.title | escape | strip_html | normalize_whitespace | escape }}" />
+<meta property="og:description" content="{{ page.excerpt | default: page.context | default: site.description | markdownify | strip_html | normalize_whitespace | escape }}" />
+<meta     name="og:image"       content="{{ page.preview-image | default: site.preview-image | absolute_url }}" />

--- a/_includes/head-twitter.html
+++ b/_includes/head-twitter.html
@@ -1,0 +1,5 @@
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:site" content="@{{ site.twitter_username }}" />
+<meta name="twitter:title" content="{{ page.title | default: site.title | escape | strip_html | normalize_whitespace | escape }}" />
+<meta name="twitter:description" content="{{ page.excerpt | default: page.context | default: site.description | markdownify | strip_html | normalize_whitespace | escape }}" />
+<meta name="twitter:image" content="{{ page.preview-image | default: site.preview-image | absolute_url }}" />

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -20,5 +20,6 @@
   <link rel="canonical" href="{{page.permalink}}" />
 
 	{% include head-twitter.html %}
+	{% include head-facebook.html %}
 
 </head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,4 +18,7 @@
     <!-- skipping google_analytics because not (jekyll.environment == 'production' and site.google_analytics) -->
   {% endif %}
   <link rel="canonical" href="{{page.permalink}}" />
+
+	{% include head-twitter.html %}
+
 </head>

--- a/_posts/2018-06-15-postit-poster.html
+++ b/_posts/2018-06-15-postit-poster.html
@@ -4,6 +4,7 @@ title:  "Post-it® Poster"
 date:   2018-06-26 09:30:30 +0100
 categories: Notes
 teaser: Notes
+preview-image: /assets/uploads/2018/06/Poster_v1.jpg
 excerpt: >
   A bit of fun with a digital version of our trade show poster
 ---

--- a/_posts/2018-11-07-janetbot.html
+++ b/_posts/2018-11-07-janetbot.html
@@ -4,6 +4,7 @@ title:  "JanetBot: Analysing gender diversity on the FT homepage"
 date:   2018-11-07 09:30:30 +0100
 categories: Product
 teaser: Product
+preview-image: /assets/uploads/2018/11/janetbot_dog.jpg
 excerpt: >
   From hackathon to MVP
 ---

--- a/_posts/2018-11-23-translations.html
+++ b/_posts/2018-11-23-translations.html
@@ -4,6 +4,7 @@ title:  "Speaking in Financial Tongues: Translations on FT.com"
 date:   2018-11-23 09:30:30 +0100
 categories: Experiment
 teaser: Experiment
+preview-image: /assets/uploads/2018/11/translation_component_french.png
 excerpt: >
   Exploring news in different languages.
 ---

--- a/_posts/2019-02-05-barcode.html
+++ b/_posts/2019-02-05-barcode.html
@@ -4,6 +4,7 @@ title:  "Barcode"
 date:   2019-02-05 09:30:30 +0100
 categories: Experiment
 teaser: Experiment
+preview-image: /assets/uploads/2019/01/barcode_header_example.jpg
 excerpt: >
   Creating art out of headline images
 ---

--- a/_posts/2019-07-01-newshack-translations.html
+++ b/_posts/2019-07-01-newshack-translations.html
@@ -4,6 +4,7 @@ title:  "BBC newsHack: Multilingual newsrooms"
 date:   2019-07-01 09:30:30 +0100
 categories: Hackathon
 teaser: Hackathon
+preview-image: /assets/uploads/2019/07/newsHack_MetaCrowd.png
 excerpt: >
   A further exploration of machine translations at BBC newsHack
 ---


### PR DESCRIPTION
## Description
Add in metadata for twitter and facebook preview views of the blog posts

## Implementation
Two new include files in head.
Added preview-image to recent blog posts.

## Screenshot
Tricky to demo without pushing it live and trying in the twitter card validator

## .env changes
none

## Additional requirements
none
