### PR TITLE
Include `o-fonts` at a specific version

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,7 @@
 	<title>{{ page.title }} | FT Labs</title>
 	<meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0,minimum-scale=1.0,user-scalable=no">
 	<script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
-  <link rel="stylesheet" href="https://build.origami.ft.com/v2/bundles/css?modules=o-fonts,o-footer@^5.4.0,o-teaser@1.12.2" />
+	<link rel="stylesheet" href="https://build.origami.ft.com/v2/bundles/css?modules=o-fonts@^2.0.0,o-footer@^5.4.0,o-teaser@1.12.2" />
 	<link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
 	<link rel='dns-prefetch' href='https://cdnjs.cloudflare.com/' />
   <link rel='dns-prefetch' href='http://s.w.org/' />


### PR DESCRIPTION
We've recently released a new version of `o-fonts` that is incompatible with these versions of the other components. That's causing a conflict which means the page isn't getting any build service CSS at all!
I've set it to the last version of `o-fonts` that works with this version of o-footer and o-teaser to get the page working again ^_^
